### PR TITLE
UPDATE: Few changes on Vagrantfile to bring it up to date.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Development environment for [Protwis](https://github.com/protwis/protwis) using 
 
 ### Instructions
 
-This guide describes how to set up a ready-to-go virtual machine with Virtualbox and Vagrant.
+This guide describes how to set up a ready-to-go virtual machine (VM) with Virtualbox and Vagrant.
 
 Works on Linux, Mac, and Windows.
 
@@ -13,12 +13,12 @@ Works on Linux, Mac, and Windows.
 * [Git][git]
 * [GitHub][github] account
 
-[vagrant]: http://www.vagrantup.com
+[vagrant]: https://www.vagrantup.com
 [virtualbox]: https://www.virtualbox.org
-[git]: http://git-scm.com
-[github]: http://www.bitbucket.org
+[git]: https://git-scm.com
+[github]: https://github.com
 
-Install Vagrant, VirtualBox, and Git, and create a GitHub account (if you don't already have one).
+Install **Vagrant**, **VirtualBox**, and **Git**, and create a **GitHub** account (if you don't already have one).
 
 Make sure you have the latest version of all three. On Ubuntu (and this may also apply to other Linux distros), the
 package manager installs an old version of Vagrant, so you will have to download and install the latest version from
@@ -44,11 +44,15 @@ Clone into the "shared" directory (replace your-username with your GitHub userna
     cd ~/protwis_vagrant
     git clone https://github.com/your-username/protwis.git shared/sites/protwis
 
-##### Add vagrant plugin
+##### Add vagrant plugins
 
 This allows for VM boxes to change disk size
 
     vagrant plugin install vagrant-disksize
+
+To mount your folders into the vagrant VM you will also need to install the guest additions plugin 
+
+    vagrant plugin install vagrant-vbguest    
 
 ##### Start the vagrant box
 
@@ -60,12 +64,13 @@ This may take a few minutes
 
     vagrant ssh
 
-##### Start the built in Django development webserver
+##### Activate the python virtual environment and start the built in Django development webserver
 
     cd /protwis/sites/protwis
-    /env/bin/python3 manage.py runserver 0.0.0.0:8000
+    source /env/bin/activate
+    ./manage.py runserver 0.0.0.0:8000
 
-You're all set up. The webserver will now be accessible from http://localhost:8000
+You're all set up. The web server will now be accessible in your local web browser at http://localhost:8000
 
 #### Windows
 
@@ -107,21 +112,23 @@ Use an SSH client, e.g. PuTTY, with the following settings
     cd /protwis/sites/protwis
     /env/bin/python3 manage.py runserver 0.0.0.0:8000
 
-You're all set up. The webserver will now be accessible from http://localhost:8000
+You're all set up. The web server will now be accessible in your local web browser at http://localhost:8000
 
 #### Other notes
 
-The protwis directory is now shared between the host machine and the virtual machine, and any changes made on the host
-machine will be instantly reflected on the server.
+The protwis directory is now shared between the *host* machine and the *virtual* machine, and any changes made on the
+host machine will be instantly reflected on the server.
 
-To run django commands from the protwis directory, ssh into the VM, and use the "/env/bin/python3" command e.g
+To run django commands from the protwis directory, ssh into the VM, and activate the python virtual environment, 
+`source /env/bin/activate` then you can start running django e.g
 
     cd ~/protwis_vagrant/
     vagrant ssh
     cd /protwis/sites/protwis
-    /env/bin/python3 manage.py check protein
+    source /env/bin/activate
+    ./manage.py check protein
 
-The database administration tool Adminer is installed and accessible at http://localhost:8001/adminer. Use the
+The database administration tool **Adminer** is installed and accessible at http://localhost:8001/adminer. Use the
 following settings
 
     System: PostgreSQL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,33 +1,87 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
 Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
 
-    # Vagrant box to build off of.
-    config.vm.box = "ubuntu/bionic64"
-    config.disksize.size = '20GB'
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "hashicorp/bionic64"
 
-    # Forward ports
-    config.vm.network :forwarded_port, guest: 22, host: 2226, id: "ssh"
-    config.vm.network :forwarded_port, guest: 8000, host: 8000
-    config.vm.network :forwarded_port, guest: 80, host: 8001
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
 
-    # Allocate resources
-    config.vm.provider :virtualbox do |vb|
-        vb.customize ["modifyvm", :id, "--ioapic", "on"]
-        vb.customize ["modifyvm", :id, "--memory", "4096"]
-        vb.customize ["modifyvm", :id, "--cpus", "4"]
-    end
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+    config.vm.network "forwarded_port", guest: 22, host: 2226, id: "ssh"
+    config.vm.network "forwarded_port", guest: 8000, host: 8000
+    config.vm.network "forwarded_port", guest: 80, host: 8001
 
-    # Set up a shared directory
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
     config.vm.synced_folder "shared", "/protwis/", :owner => "vagrant"
 
-    # copy puppet scripts to VM
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+    config.vm.provider "virtualbox" do |vb|
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      vb.memory = "1024"
+      vb.cpus = "2"
+    end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
     config.vm.provision "file", source: "protwis_puppet_modules", destination: "/protwis/conf/protwis_puppet_modules"
     config.vm.provision "shell", inline: "sudo apt-get update && sudo apt-get install -y puppet"
 
-    # Enable the Puppet provisioner
-    config.vm.provision :puppet do |puppet|
-        puppet.manifests_path = "manifests"
-        puppet.manifest_file = "default.pp"
-        puppet.module_path = "protwis_puppet_modules"
+  # Enable the Puppet provisioner
+    config.vm.provision "puppet" do |puppet|
+      puppet.manifests_path = "manifests"
+      puppet.manifest_file = "default.pp"
+      puppet.module_path = "protwis_puppet_modules"
     end
-
 end


### PR DESCRIPTION
New Vagrantfile format now uses double quotes insted of
colon say, when :puppet was used as a variable, now it's "puppet"
Also the Vagrantfile is documented according to the latest
Hashicorp default scaffold.
A correction in the README.md, bitbucket is no longer used. Also all
links are https now. Need the vbguest vagrant plugin to be able to mount
folders to the virtualbox. Also make explicit that we are using a
python vitual env for development.